### PR TITLE
DocRevision model

### DIFF
--- a/app/models/doc_revision.rb
+++ b/app/models/doc_revision.rb
@@ -1,0 +1,2 @@
+class DocRevision < ApplicationRecord
+end

--- a/db/import_doc_revisions.rb
+++ b/db/import_doc_revisions.rb
@@ -1,16 +1,30 @@
 # in repo root, run:
 # rails runner db/import_doc_revision.rb
 
-filepath_docs = "../tosback2/crawl_reviewed/"
+tosback2_repo = "https://github.com/tosdr/tosback2"
+filepath_docs = "./tosback2/crawl_reviewed/"
 
 def importDocRevision(service, doc, rev)
   data = {}
-  data['service_id'] = Service.where('"url" like \'' + service + '%\'')[0].id
-  data['name'] = doc
-  data['revision'] = rev
-  puts 'data:'
-  puts data 
+  service = Service.where('"url" like \'' + service + '%\'')[0]
+  if !service
+    return
+  end
+  imported = DocRevision.new(
+    service_id: service.id,
+    name: doc,
+    revision: rev
+  )
+  puts imported
+  unless imported.valid?
+    puts "### not imported ! ###"
+    panic
+  end
+  imported.save
 end
+
+puts "Cloning " + tosback2_repo
+`git clone --depth=1 #{tosback2_repo}`
 
 puts "Importing docs..."
 Dir.foreach(filepath_docs) do |service|

--- a/db/import_doc_revisions.rb
+++ b/db/import_doc_revisions.rb
@@ -1,0 +1,31 @@
+# in repo root, run:
+# rails runner db/import_doc_revision.rb
+
+filepath_docs = "../tosback2/crawl_reviewed/"
+
+def importDocRevision(service, doc, rev)
+  data = {}
+  data['service_id'] = Service.where('"url" like \'' + service + '%\'')[0].id
+  data['name'] = doc
+  data['revision'] = rev
+  puts 'data:'
+  puts data 
+end
+
+puts "Importing docs..."
+Dir.foreach(filepath_docs) do |service|
+  next if service == '.' or service == '..'
+  filepath_service = filepath_docs + service + '/'
+  puts filepath_service
+  Dir.foreach(filepath_service) do |doc|
+    filepath_doc = filepath_service + doc
+    puts filepath_doc
+    next if doc == '.' or doc == '..'
+    cmd = 'cd ' + filepath_docs + '; git log "' + service + '/' + doc + '"'
+    puts cmd
+    rev = `#{cmd}`.split(' ')[1]
+    puts rev
+    importDocRevision(service, doc, rev)
+  end
+end
+puts "Done!"

--- a/db/migrate/20180619102600_create_doc_revision.rb
+++ b/db/migrate/20180619102600_create_doc_revision.rb
@@ -1,0 +1,9 @@
+class CreateDocRevision < ActiveRecord::Migration[5.1]
+  def change
+    create_table :doc_revisions do |t|
+      t.string :name
+      t.string :revision
+      t.references :service, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180530131412) do
+ActiveRecord::Schema.define(version: 20180619102600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,13 @@ ActiveRecord::Schema.define(version: 20180530131412) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["point_id"], name: "index_comments_on_point_id"
+  end
+
+  create_table "doc_revisions", force: :cascade do |t|
+    t.string "name"
+    t.string "revision"
+    t.bigint "service_id"
+    t.index ["service_id"], name: "index_doc_revisions_on_service_id"
   end
 
   create_table "points", force: :cascade do |t|
@@ -141,6 +148,7 @@ ActiveRecord::Schema.define(version: 20180530131412) do
 
   add_foreign_key "cases", "topics"
   add_foreign_key "comments", "points"
+  add_foreign_key "doc_revisions", "services"
   add_foreign_key "points", "cases"
   add_foreign_key "points", "services"
   add_foreign_key "points", "topics"


### PR DESCRIPTION
This adds a DocRevision model so that we don't have to hit the github api. It also includes a script to shallow-clone tosback2 on heroku, and seed the table with the current master versions in crawl_reviewed.