### PR TITLE
Export point status

### DIFF
--- a/db/download_and_export.sh
+++ b/db/download_and_export.sh
@@ -1,0 +1,8 @@
+export DATE=`date "+%Y%m%d%H%M%S"`
+heroku pg:backups:capture --app edit-tosdr-org
+heroku pg:backups:download --app edit-tosdr-org
+mv latest.dump $DATE.dump
+pg_restore --verbose --clean --no-acl --no-owner -d phoenix_development $DATE.dump
+rails db:migrate
+rails runner db/export_points_to_old_db.rb
+rails runner db/export_services_to_old_db.rb

--- a/db/export_points_to_old_db.rb
+++ b/db/export_points_to_old_db.rb
@@ -35,17 +35,18 @@ Point.all.each do |point|
   data['quoteEnd'] = point.quoteEnd if point.quoteEnd
   data['quoteText'] = point.quoteText if point.quoteText && point.quoteText.length
   data['tosdr']['tldr'] = point.analysis
-  if (point.status == 'approved')
-    data['needModeration'] = false if data['needModeration']
-    data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
-  elsif (point.status == 'declined')
-    data['needModeration'] = false if data['needModeration']
-    data['tosdr']['irrelevant'] = true if !data['tosdr']['irrelevant']
-  else # status is 'draft', 'pending', 'disputed', or unknown
-    data['needModeration'] = true if !data['needModeration']
-    data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
+  if (!point.case_id.nil?) # if case is nil then we don't export the point status
+    if (point.status == 'approved')
+      data['needModeration'] = false if data['needModeration']
+      data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
+    elsif (point.status == 'declined')
+      data['needModeration'] = false if data['needModeration']
+      data['tosdr']['irrelevant'] = true if !data['tosdr']['irrelevant']
+    else # status is 'draft', 'pending', 'disputed', or unknown
+      data['needModeration'] = true if !data['needModeration']
+      data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
+    end
   end
-
 
   if (data['services'].nil?) then
     data['services'] = [ point.service.slug ]

--- a/db/export_points_to_old_db.rb
+++ b/db/export_points_to_old_db.rb
@@ -35,7 +35,18 @@ Point.all.each do |point|
   data['quoteEnd'] = point.quoteEnd if point.quoteEnd
   data['quoteText'] = point.quoteText if point.quoteText && point.quoteText.length
   data['tosdr']['tldr'] = point.analysis
-  # data['tosdr']['tmp_rating'] = point.rating
+  if (point.status == 'approved')
+    data['needModeration'] = false if data['needModeration']
+    data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
+  elsif (point.status == 'declined')
+    data['needModeration'] = false if data['needModeration']
+    data['tosdr']['irrelevant'] = true if !data['tosdr']['irrelevant']
+  else # status is 'draft', 'pending', 'disputed', or unknown
+    data['needModeration'] = true if !data['needModeration']
+    data['tosdr']['irrelevant'] = false if data['tosdr']['irrelevant']
+  end
+
+
   if (data['services'].nil?) then
     data['services'] = [ point.service.slug ]
   end

--- a/db/export_to_site.rb
+++ b/db/export_to_site.rb
@@ -1,0 +1,24 @@
+# in repo root, run:
+# rails runner db/export_to_site.rb
+
+require 'json'
+
+filepath_api = "../tosdr-build/dist/api/1/service/"
+
+puts "Exporting points..."
+Service.all.each do |service|
+  serviceData = {}
+#  service.points.each do |point|
+#    pointData = {}
+#    pointData['tosdr'] = {}
+#    pointData['id'] = point.id.to_s
+#    pointData['title'] = point.title
+#    pointData['tosdr']['tldr'] = point.analysis
+#    pointData['services'] = [ point.service.slug ]
+#    service_data.pointsData.push(pointData) 
+#  end
+  puts "Writing " + filepath_api + service.slug + '.json'
+  File.write(filepath_api + service.slug + '.json', JSON.pretty_unparse(serviceData))
+end
+puts "Finishing exporting to site"
+puts "Done!"


### PR DESCRIPTION
The point export script will now only export point status if the point has a case in phoenix. That way, we avoid updating points whose status was changed before cases were made compulsary, but still allow status export to work from now on! :)