### PR TITLE
Revert .buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/heroku/heroku-buildpack-ruby
-https://github.com/stomita/heroku-buildpack-phantomjs


### PR DESCRIPTION
As per https://gist.github.com/edelpero/9257311#gistcomment-1844896 you can now just add the buildpack in https://dashboard.heroku.com/apps/edit-tosdr-org/settings, so did that instead.