### PR TITLE
show only 100 items in points list

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -6,9 +6,9 @@ class PointsController < ApplicationController
 
   def index
     if params[:scope].nil? || params[:scope] == "all"
-      @points = Point.includes(:service, :case, :user).all
+      @points = Point.includes(:service, :case, :user).order("RANDOM()").limit(100)
     elsif params[:scope] == "pending"
-      @points = Point.includes(:service, :case, :user).all.where(status: "pending").where.not(user_id: current_user.id)
+      @points = Point.includes(:service, :case, :user).order("RANDOM()").limit(100).where(status: "pending").where.not(user_id: current_user.id)
     end
     if @query = params[:query]
       @points = Point.includes(:service, :case, :user).search_points_by_multiple(@query)

--- a/app/views/points/index.html.erb
+++ b/app/views/points/index.html.erb
@@ -6,17 +6,24 @@
 <% if params[:scope].nil? || params[:scope] == "all" %>
 
 <div class="row mb15">
-  <div class="col-sm-4">
+  <div class="col-sm-3">
     <div class="fl">
       <%= link_to 'All', points_path(scope: 'all'), class: 'btn btn-primary active' %>
       <%= link_to 'Pending', points_path(scope: 'pending'), class: 'btn btn-primary' %>
     </div>
   </div>
-  <div class="col-sm-4">
+  <div class="col-sm-3">
     <%= render "shared/search" %>
   </div>
-  <div class="col-sm-4">
-    <span class="fr"><button class="btn btn-success" id="orderByPoint">Order by Rating</button></span>
+  <div class="col-sm-3">
+  <% if @points.length == 100 %>
+    (showing only 100 items)
+  <% else %>
+    (showing all <%= @points.length %> items)
+  <% end %>
+  </div>
+  <div class="col-sm-3">
+    <span class="fr"><button class="btn btn-success" id="orderByPoint">Order these by Rating</button></span>
   </div>
 </div>
 
@@ -31,17 +38,24 @@
 <% elsif params[:scope] == "pending" %>
 
 <div class="row mb15">
-  <div class="col-sm-4">
+  <div class="col-sm-3">
     <div class="fl">
       <%= link_to 'All', points_path(scope: 'all'), class: 'btn btn-primary' %>
       <%= link_to 'Pending', points_path(scope: 'pending'), class: 'btn btn-primary active' %>
     </div>
   </div>
-  <div class="col-sm-4">
+  <div class="col-sm-3">
     <%= render "shared/search" %>
   </div>
-  <div class="col-sm-4">
-    <span class="fr"><button class="btn btn-success" id="orderByPoint">Order by Rating</button></span>
+  <div class="col-sm-3">
+  <% if @points.length == 100 %>
+    (showing only 100 items)
+  <% else %>
+    (showing all <%= @points.length %> items)
+  <% end %>
+  </div>
+  <div class="col-sm-3">
+    <span class="fr"><button class="btn btn-success" id="orderByPoint">Order these by Rating</button></span>
   </div>
 </div>
 


### PR DESCRIPTION
Main reason to do this is also so that when I comment on a pending point, it doesn't keep sitting there at the top of the list. And also, it seems silly to display more than 100 points in the list, right? Or who would actually use more than the top 10 or so?

In the future, it might make sense to make https://edit.tosdr.org/points/pending more like https://github.com/notifications, so you can see items where someone else added a new comment since you last viewed it. Will discuss with @Vinnl next week.