### PR TITLE
201810 curator pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,37 +1,12 @@
 class PagesController < ApplicationController
   def home
     @versions = Version.order("created_at DESC").limit(50) # .joins('INNER JOIN users ON "whodunnit"= cast(users."id" as text)')
-    if current_user&.curator then
-      @pending_points = Point
-                  .where(status: 'pending')
-                  .where.not(user_id: current_user.id)
-                  .includes(:service)
-                  .includes(:case)
-                  .includes(:user)
-                  .order(updated_at: :desc)
-                  .limit(10)
-    end
-
-    if current_user then
-      @draft_points = Point
-                  .where(status: 'draft')
-                  .where(user_id: current_user.id)
-                  .includes(:service)
-                  .includes(:case)
-                  .includes(:user)
-                  .limit(10)
-
-      @change_request_points = Point
-                  .where(status: 'changes-requested')
-                  .where(user_id: current_user.id)
-                  .includes(:service)
-                  .includes(:case)
-                  .includes(:user)
-                  .limit(10)
-    end
 
     # Only load example services for users who are not curators and don't have existing points to deal with.
-    if (!@pending_points && (!@draft_points || @draft_points.count == 0) && (!@change_request_points || @change_request_points.count == 0))
+    # Checks to see that current user does NOT have ANY points and checks to see that user is NOT a curator
+
+    if current_user.nil? || (!current_user.points.any? && !current_user.curator?)
+      @user_no_points = true
       @services = Service.includes(points: [:case])
                     .sample(3)
     end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,137 +1,135 @@
-<% if @change_request_points && @change_request_points.count > 0 then %>
-  <h2>Points that need your attention:</h2>
-  <%= render 'points/table', points: @change_request_points %>
+<!-- this needs review: current users who are curators should be able to change requests, pending points and drafts, while current users who are not curators should only be able to see change requests for their points and drafts, right? -->
+
+<% if current_user&.curator %>
+  <%= link_to "Change Requests", points_change_requests_path %> |
+  <%= link_to "Pending Points", points_pending_review_path %> |
+  <%= link_to "Drafts", points_drafts_path %>
+<% elsif current_user && !current_user.curator %>
+  <%= link_to "Change Requests", points_change_requests_path %> | |
+  <%= link_to "Drafts", points_drafts_path %>
 <% end %>
 
-<% if @draft_points && @draft_points.count > 0 then %>
-  <h2>Your drafts:</h2>
-  <%= render 'points/table', points: @draft_points %>
-<% end %>
-
-<% if @pending_points then %>
-  <h2>Points for you to review:</h2>
-  <%= render 'points/table', points: @pending_points %>
-<% end %>
-
-<% if @services then %>
-<header class="tc ph4">
-  <h1 class="fw2 mv3">
-    <strong>Terms of Service;</strong> Didn't Read
-  </h1>
-  <p>
-    <strong>“I have read and agree to the Terms”</strong> is the biggest lie on the web. We aim to fix that.
+<% if @user_no_points %>
+  <header class="tc ph4">
+    <h1 class="fw2 mv3">
+      <strong>Terms of Service;</strong> Didn't Read
+    </h1>
+    <p>
+      <strong>“I have read and agree to the Terms”</strong> is the biggest lie on the web. We aim to fix that.
+    </p>
+  </header>
+  <h2>Welcome to our edit tool</h2>
+  <p>Using this online tool, you can help to update the content of the <a href="https://tosdr.org">ToS;DR website</a>. Below are the most recent changes people made. Above, you see the menu bar, where you can for instance navigate to the list of services, or to the points search page.
   </p>
-</header>
-<h2>Welcome to our edit tool</h2>
-<p>Using this online tool, you can help to update the content of the <a href="https://tosdr.org">ToS;DR website</a>. Below are the most recent changes people made. Above, you see the menu bar, where you can for instance navigate to the list of services, or to the points search page.
-</p>
 
-<% unless user_signed_in? %>
-<div class="tc">
-  <div class="btn btn-primary btn-sm"><%= link_to "Sign up to contribute", new_user_registration_path, style:"color: white;" %> </div>
-  <div class="btn btn-secondary"><%= link_to "Login", new_user_session_path, style:"color: black;" %></div>
-</div>
-<% end %>
+  <% unless user_signed_in? %>
+  <div class="tc">
+    <div class="btn btn-primary btn-sm"><%= link_to "Sign up to contribute", new_user_registration_path, style:"color: white;" %> </div>
+    <div class="btn btn-secondary"><%= link_to "Login", new_user_session_path, style:"color: black;" %></div>
+  </div>
+  <% end %>
 
-<h2>How it works</h2>
-<p>A <em>service</em> is a website or online application, for instance YouTube. A <em>case</em> is an individual remark that can form part of the review of a service, for instance "you need to be 13 years old to use this service". A <em>point</em> links a case to a service, for instance "you need to be 13 years old to use YouTube". A <em>topic</em> is a search tag for cases.</p>
-<p>To review a service's terms and conditions, first make sure the service is listed, and add it if not. Then read the actual terms and policies you have to agree to to use this service, and make a note about anything that you find remarkable. Find the existing case for each of these review remarks, or create it if necessary, and create a point to add that case as a remark in the review of the service. Use the <a href="https://github.com/tosdr/tosdr.org/wiki/checklist">checklist</a> to see if you forgot to review any aspects.</p>
-<p>Then you need to wait for a curator to approve your changes, after which your review will show up on <a href="https://tosdr.org">https://tosdr.org</a>, will be picked up by the ToS;DR browser extensions, and included in DuckDuckGo's Privacy Grade, for which our API is one of several input factors. For services whose terms and policies are tracked by <a href="https://tosback.org">ToSBack</a>, you can try out our experimental <a href="/services/331/annotate">annotate view</a>.</p>
-<p>This tool is still very much under construction, and has bugs. Please <a href="https://github.com/tosdr/phoenix/issues/new">open a github issue</a> for anything you think should be improved.</p>
+  <h2>How it works</h2>
+  <p>A <em>service</em> is a website or online application, for instance YouTube. A <em>case</em> is an individual remark that can form part of the review of a service, for instance "you need to be 13 years old to use this service". A <em>point</em> links a case to a service, for instance "you need to be 13 years old to use YouTube". A <em>topic</em> is a search tag for cases.</p>
+  <p>To review a service's terms and conditions, first make sure the service is listed, and add it if not. Then read the actual terms and policies you have to agree to to use this service, and make a note about anything that you find remarkable. Find the existing case for each of these review remarks, or create it if necessary, and create a point to add that case as a remark in the review of the service. Use the <a href="https://github.com/tosdr/tosdr.org/wiki/checklist">checklist</a> to see if you forgot to review any aspects.</p>
+  <p>Then you need to wait for a curator to approve your changes, after which your review will show up on <a href="https://tosdr.org">https://tosdr.org</a>, will be picked up by the ToS;DR browser extensions, and included in DuckDuckGo's Privacy Grade, for which our API is one of several input factors. For services whose terms and policies are tracked by <a href="https://tosback.org">ToSBack</a>, you can try out our experimental <a href="/services/331/annotate">annotate view</a>.</p>
+  <p>This tool is still very much under construction, and has bugs. Please <a href="https://github.com/tosdr/phoenix/issues/new">open a github issue</a> for anything you think should be improved.</p>
 
 
-<h2>Examples (<%= link_to "see all", services_path %>):</h2>
-<div class="row" id="service-container">
-  <% @services.each do |s| %>
-  <div class="col-xs-12 col-sm-6 col-lg-4 serviceDiv" data-rating="<%= s.service_rating %>">
-    <!--CARD -->
-    <div class="card">
-      <h2 class="card-header card-service" title="<%= s.name %>">
-       <%= s.name %>
-     </h2>
-     <div class="card-body card-block">
-      <div class="card-text">
-        <ul>
-          <% s.points.each do |p| %>
-          <li>
-          <% if p.case&.classification == 'good' %>
-          <i class="point-good xs-icon"></i>
-          <% elsif p.case&.classification == 'neutral' %>
-          <i class="point-neutral xs-icon"></i>
-          <% elsif p.case&.classification == 'bad' %>
-          <i class ="point-bad xs-icon"></i>
-          <% elsif p.case&.classification == 'blocker' %>
-          <i class="point-blocker xs-icon"></i>
+  <h2>Examples (<%= link_to "see all", services_path %>):</h2>
+  <div class="row" id="service-container">
+    <% @services.each do |s| %>
+    <div class="col-xs-12 col-sm-6 col-lg-4 serviceDiv" data-rating="<%= s.service_rating %>">
+      <!--CARD -->
+      <div class="card">
+        <h2 class="card-header card-service" title="<%= s.name %>">
+         <%= s.name %>
+       </h2>
+       <div class="card-body card-block">
+        <div class="card-text">
+          <ul>
+            <% s.points.each do |p| %>
+            <li>
+            <% if p.case&.classification == 'good' %>
+            <i class="point-good xs-icon"></i>
+            <% elsif p.case&.classification == 'neutral' %>
+            <i class="point-neutral xs-icon"></i>
+            <% elsif p.case&.classification == 'bad' %>
+            <i class ="point-bad xs-icon"></i>
+            <% elsif p.case&.classification == 'blocker' %>
+            <i class="point-blocker xs-icon"></i>
+            <% end %>
+            &nbsp;<%= p.title  %>
+          </li>
           <% end %>
-          &nbsp;<%= p.title  %>
-        </li>
-        <% end %>
-        </ul>
-        <% if s.service_rating == "N/A" %>
-          <% badge_rating = "rating-na" %>
-        <% else %>
-          <% badge_rating = "rating-#{s.service_rating}" %>
-        <% end %>
-        <div class="card-badge <%= badge_rating %>">
-          <%= s.service_rating %>
+          </ul>
+          <% if s.service_rating == "N/A" %>
+            <% badge_rating = "rating-na" %>
+          <% else %>
+            <% badge_rating = "rating-#{s.service_rating}" %>
+          <% end %>
+          <div class="card-badge <%= badge_rating %>">
+            <%= s.service_rating %>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="card-footer">
-     <%= link_to "More", service_path(s.id), class: "btn btn-primary box-shadow-for-button" %>
+      <div class="card-footer">
+       <%= link_to "More", service_path(s.id), class: "btn btn-primary box-shadow-for-button" %>
+     </div>
    </div>
- </div>
-</div>
-<% end %>
-</div>
+  </div>
+  <% end %>
+  </div>
 <% end %>
 
-<h2>Recent changes:</h2>
-<div class="panel-group" id="accordion">
-  <% counter = 1 %>
-  <% @versions.each do |version| %>
-  <% counter += 1 %>
-  <div class="panel panel-default" id="panel<%=counter%>">
-    <div class="panel-body">
-      <div class="row">
-        <div class="col-sm-4">
-          <h5>
-            <b><%= username version.whodunnit %>:</b> <%= format_time(version.created_at) %>
+<div id="recent_changes_container">
+  <h2>Recent changes:</h2>
+  <div class="panel-group" id="accordion">
+    <% counter = 1 %>
+    <% @versions.each do |version| %>
+    <% counter += 1 %>
+    <div class="panel panel-default" id="panel<%=counter%>">
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-sm-4">
+            <h5>
+              <b><%= username version.whodunnit %>:</b> <%= format_time(version.created_at) %>
+            </h5>
+          </div>
+          <div class="col-sm-4">
+            <h5>
+              <%= version.event %>d <!-- FIXME for i18n: make this literal 'd' a function to_past_tense in app/helpers/ -->
+              <a
+              href="/<%= version.item_type.downcase %>s/<%= version.item_id %>" class="collapsed">
+              <%= version.item_type %>
+              <%= version.item_id %>
+            </a>
           </h5>
         </div>
-        <div class="col-sm-4">
-          <h5>
-            <%= version.event %>d <!-- FIXME for i18n: make this literal 'd' a function to_past_tense in app/helpers/ -->
-            <a
-            href="/<%= version.item_type.downcase %>s/<%= version.item_id %>" class="collapsed">
-            <%= version.item_type %>
-            <%= version.item_id %>
+        <div class="col-sm-4 text-right">
+          <a data-toggle="collapse" data-target="#collapse<%=counter%>" href="#collapse<%=counter%>" class="collapsed">
+            <span class="glyphicon glyphicon-chevron-down" aria-hidden="true">details</span>
           </a>
-        </h5>
-      </div>
-      <div class="col-sm-4 text-right">
-        <a data-toggle="collapse" data-target="#collapse<%=counter%>" href="#collapse<%=counter%>" class="collapsed">
-          <span class="glyphicon glyphicon-chevron-down" aria-hidden="true">details</span>
-        </a>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div id="collapse<%=counter%>" class="panel-collapse collapse">
-    <div class="panel-body">
-      <div class="row">
-        <div class="col-sm-12 mb15">
+    <div id="collapse<%=counter%>" class="panel-collapse collapse">
+      <div class="panel-body">
+        <div class="row">
+          <div class="col-sm-12 mb15">
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-sm-6">
-          <%= version.object_changes %>
-        </div>
-        <div class="col-sm-6">
+        <div class="row">
+          <div class="col-sm-6">
+            <%= version.object_changes %>
+          </div>
+          <div class="col-sm-6">
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<% end %>
+  <% end %>
+  </div>
 </div>

--- a/app/views/points/change_requests.html.erb
+++ b/app/views/points/change_requests.html.erb
@@ -1,0 +1,19 @@
+<% if current_user&.curator %>
+  <%= link_to "Pending Points", points_pending_review_path %> |
+  <%= link_to "Drafts", points_drafts_path %>
+<% elsif current_user && !current_user.curator %>
+  <%= link_to "Drafts", points_drafts_path %>
+<% end %>
+
+<% unless @points.any? %>
+  None of your points have any requested changes!
+<% end %>
+
+<h2>Requested changes:</h2>
+<div class="tabs-container tab">
+  <div class="row">
+    <div class="container card-container">
+     <%= render 'table', points: @points %>
+   </div>
+ </div>
+</div>

--- a/app/views/points/drafts.html.erb
+++ b/app/views/points/drafts.html.erb
@@ -1,0 +1,20 @@
+<% if current_user&.curator %>
+  <%= link_to "Change Requests", points_change_requests_path %> |
+  <%= link_to "Pending Points", points_pending_review_path %>
+<% elsif current_user && !current_user.curator %>
+  <%= link_to "Change Requests", points_change_requests_path %>
+<% end %>
+
+
+<% unless @points.any? %>
+  You haven't drafted any points yet! Go here to annotate a service.
+<% end %>
+
+<h2>Your drafts:</h2>
+<div class="tabs-container tab">
+  <div class="row">
+    <div class="container card-container">
+     <%= render 'table', points: @points %>
+   </div>
+ </div>
+</div>

--- a/app/views/points/pending_review.html.erb
+++ b/app/views/points/pending_review.html.erb
@@ -1,0 +1,17 @@
+<% if current_user&.curator %>
+  <%= link_to "Change Requests", points_change_requests_path %> |
+  <%= link_to "Drafts", points_drafts_path %>
+<% end %>
+
+<% unless @points.any? %>
+  At this time, there are no points awaiting your review.
+<% end %>
+
+<h2>Points pending your review:</h2>
+<div class="tabs-container tab">
+  <div class="row">
+    <div class="container card-container">
+     <%= render 'table', points: @points %>
+   </div>
+ </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
 
   get 'about', to: 'pages#about'
 
-
+  get 'points/drafts', to: 'points#drafts'
+  get 'points/change-requests', to: 'points#change_requests'
+  get 'points/pending-review', to: 'points#pending_review'
   get 'points/new', to: 'points#new'
   get 'points/:id/review', to: 'points#review', as: "review"
   patch 'points/:id/review', to: 'points#post_review'


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [->] Please explain your change

This separates out the home page into distinct pages, as I found the current layout, particularly for curators, super confusing. There's now separate pages for changes requested, points pending review, and drafts. The tab functionality is still rudimentary but can be improved upon in later iterations.

I would like to clarify a few things as part of this pull request:
- Users who are curators can view changes requested, points pending review and drafts?
- Users who are not curators can only view drafts and changes requested?

Thanks !
