### PR TITLE
added before_validation that strips attributes of trailing white space

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,5 +1,6 @@
 class Service < ApplicationRecord
   has_paper_trail
+
   has_many :points
   has_many :documents
 
@@ -11,6 +12,8 @@ class Service < ApplicationRecord
 
   attr_accessor :service_rating
 
+  before_validation :strip_input_fields
+
   def points_by_topic(query)
     points.joins(:topic).where("topics.title ILIKE ?", "%#{query}%")
   end
@@ -21,6 +24,14 @@ class Service < ApplicationRecord
 
   def service_rating
     service_rating_get
+  end
+
+  private
+
+  def strip_input_fields
+    self.attributes.each do |key, value|
+      self[key] = value.strip if value.respond_to?("strip")
+    end
   end
 
   def service_rating_get

--- a/app/views/shared/_table_services.html.erb
+++ b/app/views/shared/_table_services.html.erb
@@ -93,7 +93,11 @@
   <tbody>
   <% services.each do |s| %>
     <tr id="toSort" data-classification="<%= s.service_rating %>">
-      <td><%= link_to s.name, service_path(s) %></td>
+      <td>
+        <%= link_to service_path(s) do %>
+          <%= truncate(s.name, length: 30) %>
+        <% end %>
+      </td>
       <td><%= s.service_rating %> </td>
       <td class="text-right">
         <% if @document_counts[s.id] && @document_counts[s.id] > 0 %>


### PR DESCRIPTION
also added minor ux 'truncate' helper that truncates service names at 30 characters so that the table doesn't stretch across the page

* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please explain your change --> see above for explanation

Thanks !
