### PR TITLE
201904 captcha service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,16 +26,22 @@ gem 'sass-rails'
 gem 'simple_form'
 gem 'uglifier'
 
-gem 'recaptcha'
+gem 'invisible_captcha'
 
 # for tosback2:
 gem 'capybara'
 gem 'poltergeist'
 gem 'sanitize'
 
+
 group :development do
   gem 'letter_opener'
   gem 'web-console', '>= 3.3.0'
+  gem 'rb-readline'
+
+  # for performance
+  gem 'get_process_mem'
+  gem 'memory_profiler'
 end
 
 group :development, :test do
@@ -43,7 +49,6 @@ group :development, :test do
   gem 'bullet'
   gem 'flamegraph'
   gem 'listen', '~> 3.0.5'
-  gem 'memory_profiler'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rack-mini-profiler'

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,6 +2,8 @@ class ServicesController < ApplicationController
   before_action :authenticate_user!, except: [:show]
   before_action :set_curator, only: [:update,:destroy]
 
+  invisible_captcha only: [:create, :update], honeypot: :description
+
   def index
     @services = Service.includes(points: [:case]).all
     @document_counts = Document.group(:service_id).count
@@ -16,7 +18,7 @@ class ServicesController < ApplicationController
 
   def create
     @service = Service.new(service_params)
-    if verify_recaptcha(model: @service) && @service.save
+    if @service.save
       redirect_to service_path(@service)
     else
       render :new
@@ -96,7 +98,7 @@ class ServicesController < ApplicationController
 
   def update
     @service = Service.find(params[:id] || params[:service_id])
-    if verify_recaptcha(model: @service) && @service.update(service_params)
+    if @service.update(service_params)
       redirect_to service_path(@service)
     else
       render :edit

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -27,6 +27,8 @@ class ServicesController < ApplicationController
     authorize Service
 
     @service = Service.new(service_params)
+    @service.user = current_user
+    
     if @service.save
       redirect_to service_path(@service)
     else
@@ -108,15 +110,15 @@ class ServicesController < ApplicationController
   end
 
   def edit
-    authorize @service
-
     @service = Service.find(params[:id] || params[:service_id])
+
+    authorize @service
   end
 
   def update
-    authorize @service
-
     @service = Service.find(params[:id] || params[:service_id])
+
+    authorize @service
     if @service.update(service_params)
       redirect_to service_path(@service)
     else

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,8 @@
 class Service < ApplicationRecord
   has_paper_trail
 
+  belongs_to :user, optional: true
+
   has_many :points
   has_many :documents
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
 
   has_many :points
   has_many :documents
+  has_many :services
 
   validate :password_validation
 

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -1,7 +1,35 @@
 class ServicePolicy < ApplicationPolicy
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def annotate?
+    true
+  end
+
+  def quote?
+    true
+  end
+
+  def create?
+    !user.nil?
+  end
+
+  def update?
+    (!user.nil? && is_owner?) || (!user.nil? && user.curator?)
+  end
+
+  def destroy?
+    (!user.nil? && user.curator?)
+  end
+
+  private
+
+  def is_owner?
+    record.user.nil? ? (user.curator?) : (user == record.user)
   end
 end

--- a/app/views/services/_form.html.erb
+++ b/app/views/services/_form.html.erb
@@ -9,8 +9,8 @@
         <% if @service.id && current_user.curator? %>
           <%= f.input :is_comprehensively_reviewed, label: "This service's ToS;DR review is <a href=\"https://github.com/tosdr/tosdr.org/wiki/checklist\" target=\"_blank\" title=\"Checklist for service reviews\">comprehensive</a> and ready for publication.".html_safe %>
         <% end %>
-        <%= recaptcha_tags %>
       </div>
+      <%= invisible_captcha :description %>
       <div class="form-actions col-xs-4 col-sm-2 col-md-2">
           <%= link_to "Back", :back, class: "btn btn-default" %>
       </div>

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -19,7 +19,7 @@
 
       <div class="col-lg-6 text-right justify-content-end">
         <button class="btn btn-success" id="orderByPoint">Order Services by Rating</button>
-        <% if current_user && @services.length==0 %>
+        <% if @services.length == 0 %>
           <%= link_to 'Add Service', new_service_path, class: 'btn btn-primary mb15' %>
         <% end %>
       </div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -21,15 +21,18 @@
 
     <div class="row">
       <div class="col-lg-6">
-        <% if current_user %>
-          <% if current_user.curator? %>
+          <% if policy(@service).update? %>
             <%= link_to 'Edit Service', edit_service_path(@service), class: 'btn btn-primary smaller-btn-text' %>
           <% end %>
+          <% if current_user %>
             <%= link_to 'Add Comment', new_service_service_comment_path(@service), class: 'btn btn-link smaller-btn-text' %>
-        <% end %>
+          <% end %>
+
 
         <% if @service.documents.count == 0 %>
-          <%= link_to "Add Document", new_document_path(service: @service), title: "Add a new document to crawl", class: "btn btn-link smaller-btn-text" %>
+          <% if current_user %>
+            <%= link_to "Add Document", new_document_path(service: @service), title: "Add a new document to crawl", class: "btn btn-link smaller-btn-text" %>
+          <% end %>
         <% else %>
           <%= link_to "View Documents", annotate_service_path(@service), title: "Create points by browsing this service's documents", class: 'btn btn-link smaller-btn-text' %>
         <% end %>

--- a/config/initializers/recaptcha.rb
+++ b/config/initializers/recaptcha.rb
@@ -1,6 +1,0 @@
-Recaptcha.configure do |config|
-  config.site_key   = Rails.application.secrets[:recaptcha_site_key]
-  config.secret_key = Rails.application.secrets[:recaptcha_secret_key]
-  # Uncomment the following line if you are using a proxy server:
-  # config.proxy = 'http://myproxy.com.au:8080'
-end

--- a/db/migrate/20190430102205_add_user_ref_to_services.rb
+++ b/db/migrate/20190430102205_add_user_ref_to_services.rb
@@ -1,0 +1,5 @@
+class AddUserRefToServices < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :services, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190414103207) do
+ActiveRecord::Schema.define(version: 20190430102205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,8 @@ ActiveRecord::Schema.define(version: 20190414103207) do
     t.string "related"
     t.string "slug"
     t.boolean "is_comprehensively_reviewed", default: false, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "topic_comments", force: :cascade do |t|
@@ -217,6 +219,7 @@ ActiveRecord::Schema.define(version: 20190414103207) do
   add_foreign_key "reasons", "users"
   add_foreign_key "service_comments", "services"
   add_foreign_key "service_comments", "users"
+  add_foreign_key "services", "users"
   add_foreign_key "topic_comments", "topics"
   add_foreign_key "topic_comments", "users"
 end


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [->] Please explain your change

This ends our use of Google's recaptcha for service creation and updating, in favor of a different, independent solution. It's basically a hidden form field that scammers will detect and fill in, but real users will not. I also implemented a pundit policy for the service model, which involved a migration to connect users to the services that they create. Tested locally for non-logged-in users, logged-in users with no rights, and logged-in users with curatorial rights. Will do one more round of tests before merging.

Thanks !
