### PR TITLE
201905 service pending points

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -28,7 +28,7 @@ class ServicesController < ApplicationController
 
     @service = Service.new(service_params)
     @service.user = current_user
-    
+
     if @service.save
       redirect_to service_path(@service)
     else
@@ -90,14 +90,7 @@ class ServicesController < ApplicationController
     authorize @service
 
     if current_user
-      case params[:scope]
-      when nil
-        @points = @service.points
-      when 'pending'
-        @points = @service.points.where(status: 'pending').where.not(user_id: current_user.id)
-      when 'archived-versions'
-        @versions = @service.versions
-      end
+      @points = @service.points
     else
       @points = @service.points.where(status: 'approved')
     end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -90,7 +90,7 @@ class ServicesController < ApplicationController
     authorize @service
 
     if current_user
-      @points = @service.points
+      @points = @service.points_ordered_status_class.values.flatten
     else
       @points = @service.points.where(status: 'approved')
     end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -29,9 +29,74 @@ class Service < ApplicationRecord
     service_rating_get
   end
 
-  def ordered_points
-    service_points = points.group_by { |point| point.status }).sort_by { |key| key }.reverse.to_h
+  def points_ordered_status_class
+    service_points_hash = (points.group_by { |point| point.status }).sort_by { |key| key }.reverse.to_h
+
+    service_points_hash.each_value do |points|
+      sort_service_points(points)
+    end
   end
+
+  def sort_service_points(points)
+    classifications = ['good', 'neutral', 'bad', 'blocker']
+
+    points.sort! do |a, b|
+      a_class = a.case&.classification
+      b_class = b.case&.classification
+
+      if !classifications.include?(a.case&.classification) || !classifications.include?(b.case&.classification)
+        0
+      elsif a_class == b_class
+        0
+      elsif a_class == 'good'
+        -1
+      elsif b_class == 'good'
+        1
+      elsif a_class == 'neutral'
+        -1
+      elsif b_class == 'neutral'
+        1
+      elsif a_class == 'bad'
+        -1
+      elsif b_class == 'bad'
+        1
+      end
+    end
+  end
+
+  # function compareClassification(elementA, elementB) {
+  #   if (
+  #     !['good', 'neutral', 'bad', 'blocker'].includes(elementA.dataset.classification)
+  #     || !['good', 'neutral', 'bad', 'blocker'].includes(elementB.dataset.classification)
+  #   ) {
+  #     return 0;
+  #   }
+  #
+  #   if (elementA.dataset.classification === elementB.dataset.classification) {
+  #     return 0;
+  #   }
+  #   // Both do not have the same classification, so if one is good, that one is better:
+  #   if (elementA.dataset.classification === 'good') {
+  #     return -1;
+  #   }
+  #   if (elementB.dataset.classification === 'good') {
+  #     return 1;
+  #   }
+  #   // Both do not have the same classification, and neither is good, so if one is neutral, that one is better:
+  #   if (elementA.dataset.classification === 'neutral') {
+  #     return -1;
+  #   }
+  #   if (elementB.dataset.classification === 'neutral') {
+  #     return 1;
+  #   }
+  #   // Both do not have the same classification, and neither is good or neutral, so if one is bad, the other is a blocker:
+  #   if (elementA.dataset.classification === 'bad') {
+  #     return -1;
+  #   }
+  #   if (elementB.dataset.classification === 'bad') {
+  #     return 1;
+  #   }
+  # }
 
   private
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -29,6 +29,10 @@ class Service < ApplicationRecord
     service_rating_get
   end
 
+  def ordered_points
+    service_points = points.group_by { |point| point.status }).sort_by { |key| key }.reverse.to_h
+  end
+
   private
 
   def strip_input_fields

--- a/app/views/services/_service_points.html.erb
+++ b/app/views/services/_service_points.html.erb
@@ -1,0 +1,36 @@
+<table id="myTable" class="table table-striped">
+  <% service = false unless service %>
+  <thead>
+    <tr>
+      <% unless service %>
+      <th scope="col">Service</th>
+      <% end %>
+      <th scope="col">Title</th>
+      <th scope="col">Rating</th>
+      <th scope="col">Status</th>
+      <th scope="col">Author</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% points.each do |point| %>
+    <% if point.case&.classification == 'good' %>
+      <% pointbox = "point-good" %>
+    <% elsif point.case&.classification == 'neutral' %>
+      <% pointbox = "point-neutral" %>
+    <% elsif point.case&.classification == 'bad' %>
+      <% pointbox = "point-bad" %>
+    <% elsif point.case&.classification == 'blocker' %>
+      <% pointbox = "point-blocker" %>
+    <% end %>
+    <tr id="toSort" data-classification="<%= point.case&.classification %>">
+      <% unless service %>
+        <th scope="row"><%= point.service.name %></th>
+      <% end %>
+      <td><%= link_to point.title, point_path(point), title: "View more details" %></td>
+      <td class="<%= pointbox %>"></td>
+      <td> <%= point.status %> </td>
+      <td><%= username point.user %> </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -38,15 +38,12 @@
         <% end %>
       </div>
 
-      <div class="col-lg-6 form-inline text-right justify-content-end">
-        <button class="btn btn-success" id="orderByPoint">Order Points by Rating</button>
-      </div>
     </div> <!--/.float-right -->
     <br>
     <% if @points.empty? %>
       <p>There are no points to display at this time!</p>
     <% else %>
-      <%= render "shared/table_points", points: @points, service: true %>
+      <%= render "service_points", points: @points, service: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -39,15 +39,6 @@
       </div>
 
       <div class="col-lg-6 form-inline text-right justify-content-end">
-        <% if current_user %>
-          <% if params[:scope].nil? %>
-            <%= link_to 'All', service_path(scope: nil), class: 'btn btn-default active smaller-btn-text' %>
-            <%= link_to 'Pending', service_path(scope: 'pending'), class: 'btn btn-link smaller-btn-text' %>
-          <% elsif params[:scope] == 'pending' %>
-            <%= link_to 'All', service_path(scope: nil), class: 'btn btn-link smaller-btn-text' %>
-            <%= link_to 'Pending', service_path(scope: 'pending'), class: 'btn btn-default active smaller-btn-text' %>
-          <% end %>
-        <% end %>
         <button class="btn btn-success" id="orderByPoint">Order Points by Rating</button>
       </div>
     </div> <!--/.float-right -->
@@ -55,7 +46,7 @@
     <% if @points.empty? %>
       <p>There are no points to display at this time!</p>
     <% else %>
-      <%= render "shared/table_points", points: @points %>
+      <%= render "shared/table_points", points: @points, service: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_table_points.html.erb
+++ b/app/views/shared/_table_points.html.erb
@@ -63,9 +63,13 @@
   });
   <% end %>
 
+  <% service = false unless service %>
+
   <thead>
     <tr>
+      <% unless service %>
       <th scope="col">Service</th>
+      <% end %>
       <th scope="col">Title</th>
       <th scope="col">Rating</th>
       <th scope="col">Status</th>
@@ -84,7 +88,9 @@
       <% pointbox = "point-blocker" %>
     <% end %>
     <tr id="toSort" data-classification="<%= point.case&.classification %>">
-      <th scope="row"><%= point.service.name %></th>
+      <% unless service %>
+        <th scope="row"><%= point.service.name %></th>
+      <% end %>
       <td><%= link_to point.title, point_path(point), title: "View more details" %></td>
       <td class="<%= pointbox %>"></td>
       <td> <%= point.status %> </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,8 +40,6 @@ Rails.application.routes.draw do
   get "services/:id/annotate?point_id=:point_id", to: "services#annotate", as: "annotate_point"
   post "services/:id/annotate", to: "services#quote"
 
-  get "services/:id/(:scope)", to: "services#show", scope: /[a-z\-_]*/
-
   resources :topics do
     resources :topic_comments, only: [:new, :create]
   end


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [->] Please explain your change

This starts the re-design of the service show page that we talked about. I removed the filters for "pending" and "all" for service points, and I also removed the "order by rating" button. The points are now grouped by status, with "pending" points shown first, and ordered from best to worst within each status group.

Thanks !
