### PR TITLE
Remove topic_id from points

### DIFF
--- a/app/controllers/points_controller.rb
+++ b/app/controllers/points_controller.rb
@@ -58,7 +58,6 @@ class PointsController < ApplicationController
     authorize @point
 
     if @point.update(point_params)
-      @point.topic_id = @point.case.topic_id
       create_comment(@point.point_change)
       redirect_to point_path(@point)
     elsif @point.case.nil?
@@ -143,7 +142,7 @@ class PointsController < ApplicationController
   end
 
   def point_params
-    params.require(:point).permit(:title, :source, :status, :analysis, :topic_id, :service_id, :query, :point_change, :case_id, :document, :quoteStart, :quoteEnd, :quoteText)
+    params.require(:point).permit(:title, :source, :status, :analysis, :service_id, :query, :point_change, :case_id, :document, :quoteStart, :quoteEnd, :quoteText)
   end
 
   def check_status

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -59,7 +59,7 @@ class ServicesController < ApplicationController
     else
       @case = Case.find(params[:quoteCaseId])
       point = Point.new(
-        params.permit(:title, :source, :status, :analysis, :topic_id, :service_id, :query, :point_change, :case_id, :document, :quoteStart, :quoteEnd, :quoteText)
+        params.permit(:title, :source, :status, :analysis, :service_id, :query, :point_change, :case_id, :document, :quoteStart, :quoteEnd, :quoteText)
       )
       point.user = current_user
       point.case = @case
@@ -96,10 +96,6 @@ class ServicesController < ApplicationController
     end
 
     @versions = @service.versions
-
-    if @query = params[:topic]
-      @points = @points.where(topic_id: params[:topic][:id])
-    end
   end
 
   def edit

--- a/app/views/api/v1/points/index.json.jbuilder
+++ b/app/views/api/v1/points/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @points do |point|
-  json.extract! point, :id, :title, :source, :analysis, :rating, :topic_id, :service_id
+  json.extract! point, :id, :title, :source, :analysis, :rating, :service_id
 end

--- a/app/views/api/v1/points/show.json.jbuilder
+++ b/app/views/api/v1/points/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @point, :id, :title, :source, :analysis, :rating, :topic_id, :service_id
+json.extract! @point, :id, :title, :source, :analysis, :rating, :service_id

--- a/db/migrate/20190629203821_remove_topic_from_points.rb
+++ b/db/migrate/20190629203821_remove_topic_from_points.rb
@@ -1,0 +1,5 @@
+class RemoveTopicFromPoints < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :points, :topic_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190430102205) do
+ActiveRecord::Schema.define(version: 20190629203821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,20 +94,18 @@ ActiveRecord::Schema.define(version: 20190430102205) do
     t.text "analysis"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "topic_id"
     t.bigint "service_id"
     t.string "quoteText"
     t.bigint "case_id"
     t.string "oldId"
     t.text "point_change"
+    t.boolean "service_needs_rating_update", default: false
     t.integer "quoteStart"
     t.integer "quoteEnd"
-    t.boolean "service_needs_rating_update", default: false
     t.bigint "document_id"
     t.index ["case_id"], name: "index_points_on_case_id"
     t.index ["document_id"], name: "index_points_on_document_id"
     t.index ["service_id"], name: "index_points_on_service_id"
-    t.index ["topic_id"], name: "index_points_on_topic_id"
     t.index ["user_id"], name: "index_points_on_user_id"
   end
 
@@ -213,7 +211,6 @@ ActiveRecord::Schema.define(version: 20190430102205) do
   add_foreign_key "points", "cases"
   add_foreign_key "points", "documents"
   add_foreign_key "points", "services"
-  add_foreign_key "points", "topics"
   add_foreign_key "points", "users"
   add_foreign_key "reasons", "points"
   add_foreign_key "reasons", "users"


### PR DESCRIPTION
I am working on the latest release, I have tested this locally. Closes #846.

I am not *SURE* about all the removals of references to topic_id -- so please check those over carefully.
