### PR TITLE
Remove format_time as confusing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,10 +56,6 @@ module ApplicationHelper
     ).html_safe
   end
 
-  def format_time(time)
-    time.strftime("%d/%m/%y - %H:%M")
-  end
-
   def format_figures(figure, first = true)
     if first
       figure.nil? ? "No changes recorded" : figure.first

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -96,7 +96,7 @@
       <div class="row">
         <div class="col-sm-4">
           <h5>
-            <b><%= username version.whodunnit %>:</b> <%= format_time(version.created_at) %>
+            <b><%= username version.whodunnit %>:</b> <%= version.created_at %>
           </h5>
         </div>
         <div class="col-sm-4">

--- a/app/views/points/_table_versions.html.erb
+++ b/app/views/points/_table_versions.html.erb
@@ -12,7 +12,7 @@
       <div class="row">
         <div class="col-sm-4">
           <h5>
-              <b>Version <%= counter - 1 %>:</b> <%= format_time(version.changeset["updated_at"].nil? ? @point.updated_at : version.changeset["updated_at"].second.time) %> by <%= username version.whodunnit %>
+              <b>Version <%= counter - 1 %>:</b> <%= version.changeset["updated_at"].nil? ? @point.updated_at : version.changeset["updated_at"].second.time %> by <%= username version.whodunnit %>
           </h5>
         </div>
         <div class="col-sm-4">

--- a/app/views/services/_versions.html.erb
+++ b/app/views/services/_versions.html.erb
@@ -19,7 +19,7 @@
           No changes recorded
           <% end %>
         </td>
-        <td><%= v.changeset["updated_at"] %></td>
+        <td><%= v.created_at %></td>
         <!-- make a better view for username <td><%= v.whodunnit %></td> -->
       </tr>
       <% end %>


### PR DESCRIPTION
I am working on the latest release, and have tested locally. Closes #849.

The version history display should use the `created_at` field on the version, not the description of the changes of the `updated_at` field on the underlying object.
