### PR TITLE
Make pending count a link

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -30,6 +30,8 @@ class CasesController < ApplicationController
     @points = @case.points.includes(:service).includes(:user)
     if params[:query]
       @points = @points.search_points_by_multiple(params[:query]).where(case: @case)
+    elsif params[:status] && ['declined', 'pending', 'approved', 'changes-requested'].include?(params[:status])
+      @points = @points.where(case: @case, status: params[:status])
     end
   end
 

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-<title>Case <%= @case.id %>: <%= @case.title %> (ToS;DR Phoenix)</title>
+<title>Case <%= @case.id %>: <%= @case.title %></title>
 <% end %>
 
 <div class="card-inline">

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title do %>
-<title>Case <%= @case.id %> (ToS;DR Phoenix)</title>
+<title>Case <%= @case.id %>: <%= @case.title %> (ToS;DR Phoenix)</title>
 <% end %>
 
 <div class="card-inline">

--- a/app/views/shared/_table_cases.html.erb
+++ b/app/views/shared/_table_cases.html.erb
@@ -23,7 +23,9 @@
     <tr>
       <td><%= link_to c.title, case_path(c), title: "View points connected to this case" %></td>
       <td class="text-center"> <%= c.points.count %></td>
-      <% if current_user && current_user.curator %><td><%= c.points.where(status: 'pending').count %></td><% end %>
+      <% if current_user && current_user.curator %>
+        <td><%= link_to c.points.where(status: 'pending').count, case_path(c, status: "pending") %></td>
+      <% end %>
       <td></td>
       <td class="<%= pointbox %> text-center"></td>
       <td></td>


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [x] Have you tested it locally?
* [x] Please explain your change

This adds an optional query parameter `status` to the Case overview that allows you to filter its points by status (e.g. `?status=pending`).

It also makes the count of pending Points in a table of Cases (such as on a Topic page) link to a list of Points in that Case filtered by `pending` status.

Fixes #862.
