### PR TITLE
Removed add service button cloak on service page. Fixes #931

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -52,7 +52,7 @@
 
   <div class="article-text-holder-about">
     <p>
-      ToS;DR aims to foster a transparent and peer-reviewed process to rate and analyse terms of service and privacy policies. The goal is to generate a rating for the terms or policies from Class A to Class F, similar to a grade on a school assignment.
+      ToS;DR aims to foster a transparent and peer-reviewed process to rate and analyse terms of service and privacy policies. The goal is to generate a rating for the terms or policies from Class A to Class E, similar to a grade on a school assignment.
     </p>
     <br>
     <p>
@@ -72,7 +72,7 @@
       <li><span style="background-color:#C7E128; color:white;"> B </span> - These terms of service are fair towards the user but could be improved. Color: light green.</li>
       <li><span style="background-color:#FFB727; color:white;"> C </span> - These terms of service are okay, but some issues require your consideration. Color: yellow.</li>
       <li><span style="background-color:#F26A15; color:white;"> D </span> - These terms of service are likely skewed against you, or there are some important issues that require your attention. Color: light red.</li>
-      <li><span style="background-color:#D02620; color:white;"> F </span> - These terms of service raise very serious concerns. Color: red.</li>
+      <li><span style="background-color:#D02620; color:white;"> E </span> - These terms of service raise very serious concerns. Color: red.</li>
       <li><span style="background-color:#363636; color: white;"> N/A </span> - There is not enough data to determine the class. Color: grey</li>
     </ul>
 

--- a/app/views/services/index.html.erb
+++ b/app/views/services/index.html.erb
@@ -19,7 +19,7 @@
 
         <div class="col-lg-6 text-right justify-content-end">
           <button class="btn btn-success" v-on:click="sortServices">Order Services by Rating</button>
-          <div class="" v-if="!loading && !filteredServices.length" v-cloak>
+          <div class="">
             <% if current_user && current_user.curator %>
               <%= link_to 'Add Service', new_service_path, class: 'btn btn-primary' %>
             <% end %>


### PR DESCRIPTION
The button on the services page to add a new service disappears one the table has finished loading

This PR removes the cloak option as its not needed anyway to display the button when the table has finished loading.

This fixes #931 