### PR TITLE
fixing broken links in emails

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -34,7 +34,7 @@
 <body>
   <h1>Hi <%= @user.username? ? @user.username : "you" %>!</h1>
 
-  <p>Someone signed this email address up with Terms of Service; Didn't Read, the crowdreading tool at <a herf="https://edit.tosdr.org">edit.tosdr.org</a> (or Phoenix as we like to call it). If it wasn't you, please let us know as soon as possible, by emailing <a mailto="team@tosdr.org">team@tosdr.org</a>.</p>
+  <p>Someone signed this email address up with Terms of Service; Didn't Read, the crowdreading tool at <a href="https://edit.tosdr.org">edit.tosdr.org</a> (or Phoenix as we like to call it). If it wasn't you, please let us know as soon as possible, by emailing <a mailto="team@tosdr.org">team@tosdr.org</a>.</p>
 
   <p>Please bear in mind that this site is still in beta. You can follow the development at <a href="https://github.com/tosdr/edit.tosdr.org">our repository</a> or on <a href="https://blog.tosdr.org">our blog</a>.</p>
 

--- a/app/views/user_mailer/welcome.html.erb
+++ b/app/views/user_mailer/welcome.html.erb
@@ -34,7 +34,7 @@
 <body>
   <h1>Hi <%= @user.username? ? @user.username : "you" %>! Welcome to ToS;DR!</h1>
 
-  <p>You're now a confirmed contributor of Terms of Service; Didn't Read crowdreading tool on <a herf="https://edit.tosdr.org">Edit</a> (or Phoenix as we like to call it). If you haven't subscribed to this website, please contact as soon as possible the team at <a mailto="team@tosdr.org">team@tosdr.org</a>.</p>
+  <p>You're now a confirmed contributor of Terms of Service; Didn't Read crowdreading tool on <a href="https://edit.tosdr.org">Edit</a> (or Phoenix as we like to call it). If you haven't subscribed to this website, please contact as soon as possible the team at <a mailto="team@tosdr.org">team@tosdr.org</a>.</p>
 
   <p>Please bear in mind that this version is a beta version that is still under development. You can follow the development on <a href="https://github.com/tosdr/phoenix">our github</a> or on our <a href="https://blog.tosdr.org">blog</a>.</p>
 


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [ x] Have you tested it locally?
* [ ->] Please explain your change

links were created using `herf` and not `href`, thus breaking them in emails

Thanks !
