### PR TITLE
Fixed the Gemfile to work on Windows (+ other general changes)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'activeadmin'
 gem 'devise'
 gem 'figaro'
 gem 'jbuilder', '~> 2.0'
-gem 'pg', '~> 0.21'
+gem 'pg', '~> 1.4'
 gem "puma", ">= 3.12.4"
 gem 'rails', '~> 5.2.5'
 gem 'redis'
@@ -45,7 +45,7 @@ gem 'httparty'
 # for api pagination
 gem 'kaminari'
 
-gem 'mini_racer'
+gem 'mini_racer' if RUBY_PLATFORM !~ "mingw32" # Too many problems, is it even needed?
 
 group :development do
   gem 'letter_opener'
@@ -66,8 +66,13 @@ group :development, :test do
   gem 'rack-mini-profiler'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'stackprof'
+  gem 'stackprof' if RUBY_PLATFORM !~ "mingw32" # Not supported on Microsoft Windows
 end
 
 gem "sentry-ruby"
 gem "sentry-rails"
+
+gem 'sys-proctable'
+gem 'fast_stack'
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+gem 'tzinfo-data'


### PR DESCRIPTION
* [x] Are you working on the latest release?
* [ ] Have you tested it locally?
* [x] Please explain your change
* [ ] I have opened a [Jira Issue](https://tosdr.atlassian.net/browse/EDIT) for this Pull Request
* [ ] My Squashed Commit Message Contains the Issue Key e.g `Feature: EDIT-12 Added XXX`
Thanks !

**Version 1.2.13**
This version contains fixes for the Gemfile, in order the make Phoenix work on Microsoft Windows.
- The version for the gem 'pg' has been upgraded to 1.4.
- Due to some problems compiling the gem 'mini_racer', the Gemfile is modified so that it does not compile on Windows. I am not even sure if that gem is needed anyway.
- Because 'stackprof' is not officially supported on Windows, the Gemfile is modified so that it will not be installed on Windows.
- Added 4 new gems: 'sys-proctable', 'fast_stack', 'wdm' (for Windows Only), and 'tzinfo-data'.